### PR TITLE
feat: Flag notifications

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
                 "color": "#fff"
             },
             "optional-dependencies": [
-                "flarum/approval"
+                "flarum/approval",
+                "flarum/flags"
               ]
         },
         "flagrow": {

--- a/extend.php
+++ b/extend.php
@@ -16,7 +16,6 @@ use Flarum\Api\Serializer\BasicPostSerializer;
 use Flarum\Api\Serializer\BasicUserSerializer;
 use Flarum\Api\Serializer\CurrentUserSerializer;
 use Flarum\Extend;
-use Flarum\Flags\Event\Created as FlagCreated;
 use FoF\Subscribed\Blueprints;
 
 return [
@@ -46,5 +45,5 @@ return [
         ->subscribe(Listeners\PostCreated::class)
         ->subscribe(Listeners\UnapprovedPostCreated::class)
         ->subscribe(Listeners\UserCreated::class)
-        ->listen(FlagCreated::class, Listeners\PostWasFlagged::class),
+        ->subscribe(Listeners\PostWasFlagged::class),
 ];

--- a/extend.php
+++ b/extend.php
@@ -16,11 +16,8 @@ use Flarum\Api\Serializer\BasicPostSerializer;
 use Flarum\Api\Serializer\BasicUserSerializer;
 use Flarum\Api\Serializer\CurrentUserSerializer;
 use Flarum\Extend;
-use FoF\Subscribed\Blueprints\DiscussionCreatedBlueprint;
-use FoF\Subscribed\Blueprints\PostCreatedBlueprint;
-use FoF\Subscribed\Blueprints\PostUnapprovedBlueprint;
-use FoF\Subscribed\Blueprints\UserCreatedBlueprint;
-use FoF\Subscribed\Listeners\AddPermissions;
+use Flarum\Flags\Event\Created as FlagCreated;
+use FoF\Subscribed\Blueprints;
 
 return [
     (new Extend\Frontend('forum'))
@@ -35,10 +32,11 @@ return [
         ->namespace('fof-subscribed', __DIR__.'/resources/views'),
 
     (new Extend\Notification())
-        ->type(DiscussionCreatedBlueprint::class, BasicDiscussionSerializer::class, [])
-        ->type(PostCreatedBlueprint::class, BasicPostSerializer::class, [])
-        ->type(PostUnapprovedBlueprint::class, BasicPostSerializer::class, [])
-        ->type(UserCreatedBlueprint::class, BasicUserSerializer::class, []),
+        ->type(Blueprints\DiscussionCreatedBlueprint::class, BasicDiscussionSerializer::class, [])
+        ->type(Blueprints\PostCreatedBlueprint::class, BasicPostSerializer::class, [])
+        ->type(Blueprints\PostUnapprovedBlueprint::class, BasicPostSerializer::class, [])
+        ->type(Blueprints\UserCreatedBlueprint::class, BasicUserSerializer::class, [])
+        ->type(Blueprints\PostFlaggedBlueprint::class, BasicPostSerializer::class, []),
 
     (new Extend\ApiSerializer(CurrentUserSerializer::class))
         ->attributes(AddPermissions::class),
@@ -47,5 +45,6 @@ return [
         ->subscribe(Listeners\DiscussionCreated::class)
         ->subscribe(Listeners\PostCreated::class)
         ->subscribe(Listeners\UnapprovedPostCreated::class)
-        ->subscribe(Listeners\UserCreated::class),
+        ->subscribe(Listeners\UserCreated::class)
+        ->listen(FlagCreated::class, Listeners\PostWasFlagged::class),
 ];

--- a/js/src/admin/index.ts
+++ b/js/src/admin/index.ts
@@ -34,5 +34,13 @@ app.initializers.add('fof-subscribed', () => {
         permission: 'subscribePostUnapproved',
       },
       'moderate'
+    )
+    .registerPermission(
+      {
+        icon: 'fas fa-flag',
+        label: app.translator.trans('fof-subscribed.admin.permission.subscribe_to_post_flagged'),
+        permission: 'subscribePostFlagged'
+      },
+      'moderate'
     );
 });

--- a/js/src/forum/index.ts
+++ b/js/src/forum/index.ts
@@ -9,17 +9,20 @@ import PostUnapprovedNotification from './notifications/PostUnapprovedNotificati
 import User from 'flarum/common/models/User';
 import Model from 'flarum/common/Model';
 import ItemList from 'flarum/common/utils/ItemList';
+import PostFlaggedNotification from './notifications/PostFlaggedNotification';
 
 app.initializers.add('fof-subscribed', () => {
   app.notificationComponents.discussionCreated = DiscussionCreatedNotification;
   app.notificationComponents.postCreated = PostCreatedNotification;
   app.notificationComponents.userCreated = UserCreatedNotification;
   app.notificationComponents.postUnapproved = PostUnapprovedNotification;
+  app.notificationComponents.postFlagged = PostFlaggedNotification;
 
   User.prototype.canSubscribeDiscussionCreated = Model.attribute('canSubscribeDiscussionCreated');
   User.prototype.canSubscribePostCreated = Model.attribute('canSubscribePostCreated');
   User.prototype.canSubscribePostUnapproved = Model.attribute('canSubscribePostUnapproved');
   User.prototype.canSubscribeUserCreated = Model.attribute('canSubscribeUserCreated');
+  User.prototype.canSubscribePostFlagged = Model.attribute('canSubscribePostFlagged');
 
   extend(NotificationGrid.prototype, 'notificationTypes', (items: ItemList) => {
     const currentUser = app.session?.user;
@@ -67,6 +70,18 @@ app.initializers.add('fof-subscribed', () => {
           name: 'userCreated',
           icon: 'fas fa-user-plus',
           label: app.translator.trans('fof-subscribed.forum.settings.notify_user_created_label'),
+        },
+        -10
+      );
+    }
+
+    if (currentUser?.canSubscribePostFlagged()) {
+      items.add(
+        'postFlagged',
+        {
+          name: 'postFlagged',
+          icon: 'fas fa-flag',
+          label: app.translator.trans('fof-subscribed.forum.settings.notify_post_flagged_label'),
         },
         -10
       );

--- a/js/src/forum/notifications/PostFlaggedNotification.js
+++ b/js/src/forum/notifications/PostFlaggedNotification.js
@@ -1,0 +1,24 @@
+import app from 'flarum/forum/app';
+import Notification from 'flarum/forum/components/Notification';
+import { truncate } from 'flarum/common/utils/string';
+
+export default class PostFlaggedNotification extends Notification {
+  icon() {
+    return 'fas fa-flag';
+  }
+
+  href() {
+    const notification = this.attrs.notification;
+    const post = notification.subject();
+
+    return app.route.discussion(post.discussion(), post.postNumber);
+  }
+
+  content() {
+    return app.translator.trans('fof-subscribed.forum.notifications.post_flagged_text', { user: this.attrs.notification.fromUser() });
+  }
+
+  excerpt() {
+    return truncate(this.attrs.notification.subject().contentPlain(), 200);
+  }
+}

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -7,23 +7,27 @@ fof-subscribed:
             notify_post_created_label: Someone creates a new post or reply
             notify_post_unapproved_label: A created post needs approval
             notify_user_created_label: When someone registers
+            notify_post_flagged_label: Someone creates a new flag on a post
         notifications:
             discussion_created_text: "{username} created a new discussion"
             post_created_text: "{username} wrote a new post"
             post_unapproved_text: "{username} created a post that requires approval"
             user_created_text: "{username} had just signed up"
+            post_flagged_text: "{username} flagged a post"
     admin:
         permission:
             subscribe_to_discussion_created: Allowed to receive notification upon new discussion
             subscribe_to_post_created: Allowed to receive notification upon new post or reply
             subscribe_to_post_unapproved: Allowed to receive notification upon new unapproved post
             subscribe_to_user_created: Allowed to receive notification upon new user
+            subscribe_to_post_flagged: Allowed to receive notification upon new flag
     email:
         subject:
             newDiscussion: "[Subscribed | New Discussion] {title}"
             newUser: "[Subscribed | New User] {username}"
             postUnapproved: "[Subscribed | Unapproved] {username} posted in {title}"
             postCreated: "[Subscribed | New Post] {username} wrote a new post in {title}"
+            postFlagged: "[Subscribed | New Flag] {username} flagged a post in {title}"
         body:
             newDiscussion: |
                 Hey {recipient_display_name},
@@ -66,3 +70,11 @@ fof-subscribed:
                 ---
 
                 {post_content}
+            
+            postFlagged: |
+                Hey {recipient_display_name},
+
+                {actor_display_name} just flagged a post in {discussion_title}
+
+                To view this post, check out the following link:
+                {post_url}

--- a/resources/views/emails/postFlagged.blade.php
+++ b/resources/views/emails/postFlagged.blade.php
@@ -1,0 +1,7 @@
+{!! $translator->trans('fof-subscribed.email.body.postFlagged', [
+    '{recipient_display_name}' => $user->display_name,
+    '{actor_display_name}' => $blueprint->flag->user->display_name,
+    '{discussion_title}' => $blueprint->post->discussion->title,
+    '{post_url}' => $url->to('forum')->route('discussion', ['id' => $blueprint->post->discussion_id, 'near' => $blueprint->post->number]),
+    '{post_content}' => $blueprint->post->content,
+]) !!}

--- a/src/AddPermissions.php
+++ b/src/AddPermissions.php
@@ -9,14 +9,25 @@
  * file that was distributed with this source code.
  */
 
-namespace FoF\Subscribed\Listeners;
+namespace FoF\Subscribed;
 
 use Flarum\Api\Serializer\CurrentUserSerializer;
 use Flarum\Api\Serializer\ForumSerializer;
+use Flarum\Extension\ExtensionManager;
 use Flarum\User\User;
 
 class AddPermissions
 {
+    /**
+     * @var ExtensionManager
+     */
+    protected $extensions;
+    
+    public function __construct(ExtensionManager $extensions)
+    {
+        $this->extensions = $extensions;
+    }
+    
     /**
      * @param ForumSerializer $serializer
      */
@@ -24,8 +35,15 @@ class AddPermissions
     {
         $attributes['canSubscribeDiscussionCreated'] = $serializer->getActor()->can('subscribeDiscussionCreated');
         $attributes['canSubscribePostCreated'] = $serializer->getActor()->can('subscribePostCreated');
-        $attributes['canSubscribePostUnapproved'] = $serializer->getActor()->can('subscribePostUnapproved');
         $attributes['canSubscribeUserCreated'] = $serializer->getActor()->can('subscribeUserCreated');
+
+        if ($this->extensions->isEnabled('flarum-approval')) {
+            $attributes['canSubscribePostUnapproved'] = $serializer->getActor()->can('subscribePostUnapproved');
+        }
+
+        if ($this->extensions->isEnabled('flarum-flags')) {
+            $attributes['canSubscribePostFlagged'] = $serializer->getActor()->can('subscribePostFlagged');
+        }
 
         return $attributes;
     }

--- a/src/Blueprints/PostFlaggedBlueprint.php
+++ b/src/Blueprints/PostFlaggedBlueprint.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace FoF\Subscribed\Blueprints;
+
+use Flarum\Flags\Flag;
+use Flarum\Notification\Blueprint\BlueprintInterface;
+use Flarum\Notification\MailableInterface;
+use Flarum\Post\Post;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class PostFlaggedBlueprint implements BlueprintInterface, MailableInterface
+{
+    /**
+     * @var Post
+     */
+    public $post;
+
+    /**
+     * @var Flag
+     */
+    public $flag;
+
+    /**
+     * @param Post $post
+     */
+    public function __construct(Post $post, Flag $flag)
+    {
+        $this->post = $post;
+        $this->flag = $flag;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSender()
+    {
+        return $this->flag->user;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSubject()
+    {
+        return $this->post;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getType()
+    {
+        return 'postFlagged';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubjectModel()
+    {
+        return Post::class;
+    }
+
+    /**
+     * Get the name of the view to construct a notification email with.
+     *
+     * @return array
+     */
+    public function getEmailView()
+    {
+        return ['text' => 'fof-subscribed::emails.postFlagged'];
+    }
+
+    /**
+     * Get the subject line for a notification email.
+     *
+     * @return string
+     */
+    public function getEmailSubject(TranslatorInterface $translator)
+    {
+        return $translator->trans('fof-subscribed.email.subject.postFlagged', [
+            '{username}' => $this->flag->user->display_name,
+            '{title}'    => $this->post->discussion->title,
+        ]);
+    }
+
+    public function getFromUser()
+    {
+        return $this->flag->user;
+    }
+}

--- a/src/Jobs/SendNotificationWhenPostIsFlagged.php
+++ b/src/Jobs/SendNotificationWhenPostIsFlagged.php
@@ -23,7 +23,7 @@ class SendNotificationWhenPostIsFlagged extends AbstractJob
     
     public function handle(NotificationSyncer $notifications)
     {
-        $post = $this->flag->post();
+        $post = $this->flag->post;
         $flag = $this->flag;
 
         $notify = User::query()
@@ -31,8 +31,8 @@ class SendNotificationWhenPostIsFlagged extends AbstractJob
             ->where('preferences', 'regexp', new Expression('\'"notify_postFlagged_[a-z]+":true\''))
             ->get();
 
-        $notify = $notify->filter(function (User $recipient) use ($flag) {
-            return $recipient->can('subscribePostFlagged') && $flag->isVisibleTo($recipient);
+        $notify = $notify->filter(function (User $recipient) use ($post) {
+            return $recipient->can('subscribePostFlagged') && $recipient->can('viewFlags', $post->discussion);
         });
 
         $notifications->sync(

--- a/src/Jobs/SendNotificationWhenPostIsFlagged.php
+++ b/src/Jobs/SendNotificationWhenPostIsFlagged.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace FoF\Subscribed\Jobs;
+
+use Flarum\Flags\Flag;
+use Flarum\Notification\NotificationSyncer;
+use Flarum\User\User;
+use Flarum\Queue\AbstractJob;
+use FoF\Subscribed\Blueprints\PostFlaggedBlueprint;
+use Illuminate\Database\Query\Expression;
+
+class SendNotificationWhenPostIsFlagged extends AbstractJob
+{
+    /**
+     * @var Flag
+     */
+    protected $flag;
+
+    public function __construct(Flag $flag)
+    {
+        $this->flag = $flag;
+    }
+    
+    public function handle(NotificationSyncer $notifications)
+    {
+        $post = $this->flag->post();
+        $flag = $this->flag;
+
+        $notify = User::query()
+            ->where('users.id', '!=', $flag->actor->id)
+            ->where('preferences', 'regexp', new Expression('\'"notify_postFlagged_[a-z]+":true\''))
+            ->get();
+
+        $notify = $notify->filter(function (User $recipient) use ($flag) {
+            return $recipient->can('subscribePostFlagged') && $flag->isVisibleTo($recipient);
+        });
+
+        $notifications->sync(
+            new PostFlaggedBlueprint($post, $flag),
+            $notify->all()
+        );
+    }
+}

--- a/src/Listeners/PostWasFlagged.php
+++ b/src/Listeners/PostWasFlagged.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace FoF\Subscribed\Listeners;
+
+use Flarum\Flags\Event\Created;
+use FoF\Subscribed\Jobs\SendNotificationWhenPostIsFlagged;
+
+class PostWasFlagged
+{
+    public function handle(Created $event): void
+    {
+        resolve('flarum.queue.connection')->push(
+            new SendNotificationWhenPostIsFlagged($event->flag)
+        );
+    }
+}

--- a/src/Listeners/PostWasFlagged.php
+++ b/src/Listeners/PostWasFlagged.php
@@ -3,14 +3,52 @@
 namespace FoF\Subscribed\Listeners;
 
 use Flarum\Flags\Event\Created;
+use Flarum\Flags\Event\Deleting;
+use Flarum\Flags\Flag;
+use Flarum\Notification\NotificationSyncer;
+use FoF\Subscribed\Blueprints\PostFlaggedBlueprint;
 use FoF\Subscribed\Jobs\SendNotificationWhenPostIsFlagged;
+use Illuminate\Contracts\Events\Dispatcher;
 
 class PostWasFlagged
 {
-    public function handle(Created $event): void
+    /**
+     * @var NotificationSyncer
+     */
+    protected $notifications;
+
+    /**
+     * @param NotificationSyncer $notifications
+     */
+    public function __construct(NotificationSyncer $notifications)
+    {
+        $this->notifications = $notifications;
+    }
+    
+    /**
+     * @param Dispatcher $events
+     */
+    public function subscribe(Dispatcher $events)
+    {
+        $events->listen(Created::class, [$this, 'whenFlagged']);
+        $events->listen(Deleting::class, [$this, 'whenFlagDismissed']);
+    }
+    
+    public function whenFlagged(Created $event): void
     {
         resolve('flarum.queue.connection')->push(
             new SendNotificationWhenPostIsFlagged($event->flag)
         );
+    }
+
+    public function whenFlagDismissed(Deleting $event): void
+    {
+        // remove notifications for this flag when it is dismissed
+        $this->notifications->delete($this->getNotification($event->flag->post, $event->flag));
+    }
+
+    protected function getNotification($post, Flag $flag)
+    {
+        return new PostFlaggedBlueprint($post, $flag);
     }
 }


### PR DESCRIPTION
Allow subscriptions to new flags.

Whilst the `alert` notification is probably redundant, the email option could be useful for moderators who are not always online.
