### PR TITLE
fix: User link Cannot use ::class with dynamic class name

### DIFF
--- a/resources/views/emails/userCreated.blade.php
+++ b/resources/views/emails/userCreated.blade.php
@@ -2,5 +2,5 @@
     '{recipient_display_name}' => $user->display_name,
     '{actor_display_name}' => $blueprint->user->display_name,
     '{forum_url}' => $url->to('forum')->base(),
-    '{user_url}' => $url->to('forum')->route('user', ['username' => $slugManager->forResource($blueprint->user::class)->toSlug($blueprint->user)]),
+    '{user_url}' => $url->to('forum')->route('user', ['username' => $slugManager->forResource(get_class($blueprint->user))->toSlug($blueprint->user)]),
 ]) !!}


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #25 **

**Changes proposed in this pull request:**
Replaces the `::class` with a `get_class` on the `$blueprint->user`

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
Screenshot shows email dumped to logs is working after reigstration.
<img width="760" alt="Screen Shot 2022-12-04 at 9 20 29 AM" src="https://user-images.githubusercontent.com/5262154/205495907-223a39d2-41c0-46fb-a1db-93d87a9520c0.png">


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).


